### PR TITLE
Fix: entrantId 필드가 null인 오류

### DIFF
--- a/Client/Assets/Scripts/Lobby/MatchRoomListFetcher.cs
+++ b/Client/Assets/Scripts/Lobby/MatchRoomListFetcher.cs
@@ -192,7 +192,7 @@ public class CONTENT_TYPE
 {
     public long matchRoomId;
     public long hostId;
-    public long entrantId;
+    public long? entrantId;
     public MatchStatus matchStatus { get; set; }
     public int stakeGold;
 }


### PR DESCRIPTION
InvalidCastException: Null object cannot be converted to a value type. 오류로 인해 JSON 역직렬화 수행이 안되었음